### PR TITLE
feat: Add auto-rating for tracks with same ISRC

### DIFF
--- a/dist/star-ratings.js
+++ b/dist/star-ratings.js
@@ -1,3 +1,1261 @@
-!async function(){for(;!Spicetify.React||!Spicetify.ReactDOM;)await new Promise(e=>setTimeout(e,10));var u,r,p,a,f,c,m,d,y,b,g,i,n,S,v,h,o,w,l,s,t,k,E,x,P,N,R,e;u=Spicetify.React,r=Spicetify.React,p=[null,null,null,null,"[index] 16px [first] 4fr [var1] 2fr [var2] 1fr [last] minmax(120px,1fr)","[index] 16px [first] 6fr [var1] 4fr [var2] 3fr [var3] 2fr [last] minmax(120px,1fr)","[index] 16px [first] 6fr [var1] 4fr [var2] 3fr [var3] minmax(120px,2fr) [var3] 2fr [last] minmax(120px,1fr)"],a=()=>Spicetify.Player.data.item.uri,m={},d={},y={},v=[],x=E=k=t=s=l=w=o=S=n=i=g=b=c=f=null,R=N=P=!(h=[]),e=async function(){for(;!Spicetify?.showNotification;)await new Promise(e=>setTimeout(e,100));Y(f=function(){var e={halfStarRatings:!0,likeThreshold:"4.0",enableKeyboardShortcuts:!0,showPlaylistStars:!0,nowPlayingStarsPosition:"left",skipThreshold:"disabled"};settings={};try{var t=JSON.parse(K("starRatings:settings"));if(!t||"object"!=typeof t)throw"";settings=t}catch{return L("starRatings:settings",e),e}let i=!1;for(const r of Object.keys(e))settings.hasOwnProperty(r)||(settings[r]=e[r],i=!0);return i&&L("starRatings:settings",settings),settings}()),await pe();const e={"5.0":Spicetify.Keyboard.KEYS.NUMPAD_0,.5:Spicetify.Keyboard.KEYS.NUMPAD_1,"1.0":Spicetify.Keyboard.KEYS.NUMPAD_2,1.5:Spicetify.Keyboard.KEYS.NUMPAD_3,"2.0":Spicetify.Keyboard.KEYS.NUMPAD_4,2.5:Spicetify.Keyboard.KEYS.NUMPAD_5,"3.0":Spicetify.Keyboard.KEYS.NUMPAD_6,3.5:Spicetify.Keyboard.KEYS.NUMPAD_7,"4.0":Spicetify.Keyboard.KEYS.NUMPAD_8,4.5:Spicetify.Keyboard.KEYS.NUMPAD_9},o=re(e),l=(t=e,()=>{for(const e of Object.values(t))Spicetify.Keyboard._deregisterShortcut({key:e,ctrl:!0,alt:!0})});var t;const s=()=>{x&&x[0].remove(),w=null,le(e)};new Spicetify.Menu.Item("Star Ratings",!0,()=>{var e,t,i,r,a,n;Spicetify.PopupModal.display({title:"Star Ratings",content:({settings:e,registerKeyboardShortcuts:t,deregisterKeyboardShortcuts:i,updateTracklist:r,restoreTracklist:a,redrawNowPlayingStars:n}=[{settings:f,registerKeyboardShortcuts:o,deregisterKeyboardShortcuts:l,updateTracklist:oe,restoreTracklist:ne,redrawNowPlayingStars:s}][0],u.createElement("div",null,u.createElement(J,{value:"Settings"}),u.createElement($,{settings:e,name:"Half star ratings",field:"halfStarRatings"}),u.createElement($,{settings:e,name:"Enable keyboard shortcuts",field:"enableKeyboardShortcuts",onclick:function(){(e.enableKeyboardShortcuts?t:i)()}}),u.createElement($,{settings:e,name:"Show playlist stars",field:"showPlaylistStars",onclick:function(){(e.showPlaylistStars?r:a)()}}),u.createElement(G,{settings:e,name:"Auto-like/dislike threshold",field:"likeThreshold",options:{Disabled:"disabled","3.0":"3.0",3.5:"3.5","4.0":"4.0",4.5:"4.5","5.0":"5.0"}}),u.createElement(G,{settings:e,name:"Now playing stars position",field:"nowPlayingStarsPosition",options:{Left:"left",Right:"right"},onclick:function(){n()}}),u.createElement(G,{settings:e,name:"Skip threshold",field:"skipThreshold",options:{Disabled:"disabled","0.0":"0.0",.5:"0.5","1.0":"1.0",1.5:"1.5","2.0":"2.0",2.5:"2.5","3.0":"3.0",3.5:"3.5","4.0":"4.0",4.5:"4.5"}}),u.createElement(J,{value:"Keyboard Shortcuts"}),u.createElement("ul",null,u.createElement(_,{label:"Rate current track 0.5 stars",numberKey:"1"}),u.createElement(_,{label:"Rate current track 1 star",numberKey:"2"}),u.createElement(_,{label:"Rate current track 1.5 stars",numberKey:"3"}),u.createElement(_,{label:"Rate current track 2 stars",numberKey:"4"}),u.createElement(_,{label:"Rate current track 2.5 stars",numberKey:"5"}),u.createElement(_,{label:"Rate current track 3 stars",numberKey:"6"}),u.createElement(_,{label:"Rate current track 3.5 stars",numberKey:"7"}),u.createElement(_,{label:"Rate current track 4 stars",numberKey:"8"}),u.createElement(_,{label:"Rate current track 4.5 stars",numberKey:"9"}),u.createElement(_,{label:"Rate current track 5 stars",numberKey:"0"})))),isLarge:!0})}).register(),S=new MutationObserver(()=>{oe()}),Spicetify.Player.addEventListener("songchange",()=>{var e=Spicetify.Player.data.item.uri;e in m&&"disabled"!==f.skipThreshold&&m[e]<=parseFloat(f.skipThreshold)?Spicetify.Player.next():ce()}),Spicetify.Platform.History.listen(async()=>{await se()}),new Spicetify.ContextMenu.Item("Use as Rated folder",e=>{U(c=e[0]),N=!0,pe().finally(()=>{N=!1})},ue).register(),new Spicetify.ContextMenu.Item("Sort by rating",e=>{var t,i;Spicetify.PopupModal.display({title:"Modify Custom order?",content:({onClickCancel:t,onClickOK:i}=[{onClickCancel:()=>{Spicetify.PopupModal.hide()},onClickOK:()=>{Spicetify.PopupModal.hide(),R=!0,A("Sorting..."),X(e[0],m).finally(()=>{R=!1})}}][0],r.createElement("div",{className:"parent-div"},r.createElement("p",null,"This will modify the ",r.createElement("b",null,"Custom order")," of the playlist."),r.createElement("div",{className:"button-div"},r.createElement(V,{name:"Cancel",className:"cancel-button",onButtonClick:t}),r.createElement(V,{name:"Sort",className:"ok-button",onButtonClick:i}))))})},de).register();var i=new MutationObserver(async()=>{await le(e)});await le(e),i.observe(document.body,{childList:!0,subtree:!0})},(async()=>{await e()})();function A(e){Spicetify.showNotification(e)}function K(e){return Spicetify.LocalStorage.get(e)}function L(e,t){Spicetify.LocalStorage.set(e,t)}async function O(e,t){t=navigator.platform.startsWith("Linux")&&navigator.userAgent.includes("Spotify/1.1.84.716")?{after:t}:{after:{uri:t}};return Spicetify.CosmosAsync.post(`https://api.spotify.com/v1/users/${Spicetify.User.getUsername()}/playlists`,{name:e,...t})}async function B(e){setTimeout(async()=>{await Spicetify.CosmosAsync.post(`sp://core-playlist/v1/playlist/${e}/set-base-permission`,{permission_level:"BLOCKED"})},1e3)}async function C(){return Spicetify.Platform.RootlistAPI.getContents()}async function j(e){(await Spicetify.Platform.LibraryAPI.contains(e))[0]||await Spicetify.Platform.LibraryAPI.add({uris:[e],silent:0})}async function D(e,t){await Spicetify.Platform.PlaylistAPI.remove(e,[{uri:t,uid:""}])}async function T(e){return(await Spicetify.CosmosAsync.get("sp://core-playlist/v1/playlist/"+e)).items}async function q(e){return 1===(await Spicetify.CosmosAsync.get("sp://desktop/v1/version")).version.localeCompare(e,void 0,{numeric:!0,sensitivity:"base"})}function H(e,t){var i,r,a,n=document.createElement("span"),o="stars-"+e,l=(n.className="stars",n.id=o,n.style.whiteSpace="nowrap",n.style.alignItems="center",n.style.display="flex",[]);for(let e=0;e<5;e++){u=o,i=e+1,c=t,a=r=s=void 0,s="http://www.w3.org/2000/svg",r=document.createElementNS(s,"svg"),u=u+"-"+i,r.id=u,r.style.minHeight=c+"px",r.style.minWidth=c+"px",r.setAttributeNS(null,"width",c+"px"),r.setAttributeNS(null,"height",c+"px"),r.setAttributeNS(null,"viewBox","0 0 32 32"),i=document.createElementNS(s,"defs"),r.append(i),c=document.createElementNS(s,"linearGradient"),i.append(c),c.id=u+"-gradient",i=document.createElementNS(s,"stop"),c.append(i),i.id=u+"-gradient-first",i.setAttributeNS(null,"offset","50%"),i.setAttributeNS(null,"stop-color","var(--spice-button-disabled)"),a=document.createElementNS(s,"stop"),c.append(a),a.id=u+"-gradient-second",a.setAttributeNS(null,"offset","50%"),a.setAttributeNS(null,"stop-color","var(--spice-button-disabled)"),u=document.createElementNS(s,"path"),r.append(u),u.setAttributeNS(null,"fill",`url(#${c.id})`),u.setAttributeNS(null,"d","M20.388,10.918L32,12.118l-8.735,7.749L25.914,31.4l-9.893-6.088L6.127,31.4l2.695-11.533L0,12.118l11.547-1.2L16.026,0.6L20.388,10.918z");var[s,c,u]=[r,i,a];n.append(s),l.push([s,c,u])}return[n,l]}function I(t,e){var i=e/=.5;for(let e=0;e<5;e++){var r=t[e][1],a=t[e][2];r.setAttributeNS(null,"stop-color","var(--spice-button-disabled)"),a.setAttributeNS(null,"stop-color","var(--spice-button-disabled)")}for(let e=0;e<i;e++){var n=Math.floor(e/2),o=t[n][1],n=t[n][2];(e%2==0?o:n).setAttributeNS(null,"stop-color","var(--spice-button)")}}function F(e,t,i){t=t.getBoundingClientRect(),t=event.clientX-t.left;let r=i+1;return 8<t||!e.halfStarRatings||(r-=.5),0===i&&t<3&&(r-=e.halfStarRatings?.5:1),r}function Y(e){L("starRatings:settings",JSON.stringify(e))}function M(e){L("starRatings:playlistUris",JSON.stringify(e))}function U(e){L("starRatings:ratedFolderUri",e)}function z(){return u.createElement("svg",{width:16,height:16,viewbox:"0 0 16 16",fill:"currentColor",dangerouslySetInnerHTML:{__html:Spicetify.SVGIcons.check}})}function $({settings:t,name:e,field:i,onclick:r}){let[a,n]=Spicetify.React.useState(t[i]);var o=a?"checkbox":"checkbox disabled";return u.createElement("div",{className:"popup-row"},u.createElement("label",{className:"col description"},e),u.createElement("div",{className:"col action"},u.createElement("button",{className:o,onClick:function(){var e=!a;t[i]=e,n(e),Y(t),r&&r()}},u.createElement(z,null))))}function G({settings:t,name:e,field:i,options:r,onclick:a}){const[n,o]=Spicetify.React.useState(t[i]);var l,s,c=[];for([l,s]of Object.entries(r))c.push(u.createElement("option",{value:s},l));return u.createElement("div",{className:"popup-row"},u.createElement("label",{className:"col description"},e),u.createElement("div",{className:"col action"},u.createElement("select",{value:n,onChange:function(e){o(e.target.value),t[i]=e.target.value,Y(t),a&&a()}},c)))}function _({label:e,numberKey:t}){return u.createElement("li",{className:"main-keyboardShortcutsHelpModal-sectionItem"},u.createElement("span",{className:"Type__TypeElement-goli3j-0 ipKmGr main-keyboardShortcutsHelpModal-sectionItemName"},e),u.createElement("kbd",{className:"Type__TypeElement-goli3j-0 ipKmGr main-keyboardShortcutsHelpModal-key"},"Ctrl"),u.createElement("kbd",{className:"Type__TypeElement-goli3j-0 ipKmGr main-keyboardShortcutsHelpModal-key"},"Alt"),u.createElement("kbd",{className:"Type__TypeElement-goli3j-0 ipKmGr main-keyboardShortcutsHelpModal-key"},t))}function J({value:e}){return u.createElement("h2",{className:"Type__TypeElement-goli3j-0 bcTfIx main-keyboardShortcutsHelpModal-sectionHeading"},e)}function V({name:e,className:t,onButtonClick:i}){return r.createElement("button",{className:t,onClick:i},e)}function W(e,t){return e.items.find(e=>"folder"===e.type&&e.name===t)}async function X(i,r){const a=["5.0","4.5","4.0","3.5","3.0","2.5","2.0","1.5","1.0","0.5","0.0"];var n=await T(i);if(0!==n.length){var o={};for(const p of a)o[p]=[];for(const f of n){let e=r[f.link]??0;o[e="number"==typeof e?e.toFixed(1):e].push(f.rowId)}let e=function(e){for(const t of a)if(0<e[t].length)return e[t][0];return null}(o);var l,s,c,u,n=n[0].rowId,d=e===n;let t=!0;for(const m of a)0!==o[m].length&&(!d&&t?(l=i,s=o[m],c=e,u=void 0,u=await q("1.2.5.1006.g22820f93"),await Spicetify.Platform.PlaylistAPI.move(l,s.map(e=>({uid:e})),{before:u?{uid:c}:c})):(l=i,s=o[m],u=e,c=void 0,c=await q("1.2.5.1006.g22820f93"),await Spicetify.Platform.PlaylistAPI.move(l,s.map(e=>({uid:e})),{after:c?{uid:u}:u})),t=!1,e=o[m].slice(-1)[0])}}function Q(){var e=Spicetify.Platform.History.location.pathname.match(/album\/(.*)/);return e?e[1]:null}function Z(e){return e.replace("spotify:track:","")}function ee(){var e=function(e,t){if(console.log("album is:",t),!t)return"0.0";let i=0,r=0;for(const o of t.tracks.items){var a=o.uri,a=parseFloat(e[a]);a&&(i+=a,r+=1)}let n=0;return 0<r&&(n=i/r),(n=Math.round(2*n)/2).toFixed(1)}(m,k);I(E[1],e)}async function te(e,t,r){try{var a;m[e]=r,t&&await D(y[t],e),c||(await Spicetify.Platform.RootlistAPI.createFolder("Rated",{before:""}),a=W(await C(),"Rated"),U(c=a.uri));let i=y[r];var n=r;if(i){if(8e3<=(await T(i)).length){let t=1,e;for(;;)try{var o=`${r}(${t})`;await B(e=await O(o,c));break}catch(e){if(100<++t)throw new Error("Unable to create overflow playlist")}i=e,y[r]=e,M(y),d[e]=`${r}(${t})`}}else await B(i=await O(n,c)),y[r]=i,M(y),d[i]=n;l=i,await Spicetify.Platform.PlaylistAPI.add(l,[e],{after:1,before:0}),A((t?"Moved":"Added")+" to "+d[i]),"disabled"!==f.likeThreshold&&parseFloat(f.likeThreshold)<=parseFloat(r)&&await j(e)}catch(e){console.error("Error in handleSetRating:",e),A("Error updating rating: "+(e.message||"Unknown error"))}var l}function ie(o,l,s,c){return()=>{if(!(P||N||R)){P=!0;var[,r]=s,r=r[o][0];const a=c(),n=m[a];let t=null!==l?l:F(f,r,o).toFixed(1),e=null,i=null;n===t?(i=0,e=async function(e,t){delete m[e];var t=y[t],i=d[t];await D(t,e),A("Removed from "+i)}(a,t)):(i=t,e=te(a,n,t),"disabled"!==f.likeThreshold&&t>=parseFloat(f.likeThreshold)&&j(a)),e.finally(()=>{var e=function(e){var t="stars-"+e;if(!(e=document.getElementById(t)))return null;var i=[];for(let e=1;e<=5;e++){var r=t+"-"+e,a=document.getElementById(r),n=document.getElementById(r+"-gradient-first"),r=document.getElementById(r+"-gradient-second");i.push([a,n,r])}return[e,i]}(Z(a));e&&(I(e[1],i),e[0].style.visibility=n===t?"hidden":"visible"),ce(),P=!1})}}}function re(i){return()=>{for(var[e,t]of Object.entries(i))Spicetify.Keyboard.registerShortcut({key:t,ctrl:!0,alt:!0},ie(0,parseFloat(e),x,a))}}function ae(e,i){const[t,r]=e;t.addEventListener("mouseout",function(){var e;I(r,(e=i(),m[e]??0))});for(let t=0;t<5;t++){const a=r[t][0];a.addEventListener("mousemove",function(){var e=F(f,a,t);I(r,e)}),a.addEventListener("click",ie(t,null,e,i))}}function ne(){document.querySelectorAll(".main-trackList-trackListHeaderRow").forEach(e=>{e.style["grid-template-columns"]=b});for(const r of Array.from(v)){var e=r.getElementsByClassName("main-trackList-trackListRow");for(const a of Array.from(e)){var t,i=a.querySelector(".starRatings");i&&(a.style["grid-template-columns"]=g,i.remove(),i=a.querySelector(".main-trackList-rowSectionEnd"),t=parseInt(i.getAttribute("aria-colindex")),i.setAttribute("aria-colindex",(t-1).toString()))}}}function oe(){if(f.showPlaylistStars){h=v;let t=(v=Array.from(document.querySelectorAll(".main-trackList-indexable"))).length!==h.length;for(let e=0;e<v.length;e++)v[e].isEqualNode(h[e])||(t=!0);t&&(g=b=null);{var e=v;let i=null;var r=document.querySelectorAll(".main-trackList-trackListHeaderRow");r.forEach(e=>{var t=e.querySelector(".main-trackList-rowSectionEnd"),t=parseInt(t.getAttribute("aria-colindex"));(b=b||getComputedStyle(e).gridTemplateColumns)&&p[t]&&(e.style["grid-template-columns"]=p[t],i=p[t])});for(const s of e)for(const c of s.getElementsByClassName("main-trackList-trackListRow")){var a=0<c.getElementsByClassName("stars").length;const u=function(e){return(e=Object.values(e))?(e=e[0]?.pendingProps?.children[0]?.props?.children)?.props?.uri||e?.props?.children?.props?.uri||e?.props?.children?.props?.children?.props?.uri||e[0]?.props?.uri:null}(c);var n=u.includes("track");let e=c.querySelector(".starRatings");if(e||(o=c.querySelector(".main-trackList-rowSectionEnd"),l=parseInt(o.getAttribute("aria-colindex")),o.setAttribute("aria-colindex",(l+1).toString()),(e=document.createElement("div")).setAttribute("aria-colindex",l.toString()),e.role="gridcell",e.style.display="flex",e.classList.add("main-trackList-rowSectionVariable"),e.classList.add("starRatings"),c.insertBefore(e,o),g=g||getComputedStyle(c).gridTemplateColumns,p[l]&&(c.style["grid-template-columns"]=i||p[l])),u&&!a&&n){var o=H(Z(u),16);const d=o[0];var l=o[1],a=m[u]??0;e.appendChild(d),I(l,a),ae(o,()=>u),d.style.visibility=void 0!==m[u]?"visible":"hidden",c.addEventListener("mouseover",()=>{d.style.visibility="visible"}),c.addEventListener("mouseout",()=>{d.style.visibility=void 0!==m[u]?"visible":"hidden"})}}}}}async function le(e){i=n,(n=document.querySelector("main"))&&!n.isEqualNode(i)&&(i&&S.disconnect(),oe(),S.observe(n,{childList:!0,subtree:!0})),o=w;var t="left"===f.nowPlayingStarsPosition?".main-nowPlayingWidget-nowPlaying .main-trackInfo-container":".main-nowPlayingBar-right div";(w=document.querySelector(t))&&!w.isEqualNode(o)&&((x=H("now-playing",16))[0].style.marginLeft="8px",x[0].style.marginRight="8px","left"===f.nowPlayingStarsPosition?w.after(x[0]):w.prepend(x[0]),ae(x,a),ce(),f.enableKeyboardShortcuts)&&re(e)(),l=s,(s=document.querySelector(".main-actionBar-ActionBar .ix_8kg3iUb9VS5SmTnBY"))&&!s.isEqualNode(l)&&null!==Q()&&(E=H("album",32),s.after(E[0]),await se())}async function se(){var e;E&&(t=Q(),E[0].style.display=t?"flex":"none",console.log("albumId is:",t),t)&&(e=t,k=await Spicetify.CosmosAsync.get("https://api.spotify.com/v1/albums/"+e,{offset:0,limit:450}),ee())}function ce(){var e,t;x&&(t=(e=Spicetify.Player.data.item.uri).includes("track"),x[0].style.display=t?"flex":"none",t=m[e]??0,I(x[1],t))}function ue(e){return Spicetify.URI.fromString(e[0]).type===Spicetify.URI.Type.FOLDER}function de(e){switch(Spicetify.URI.fromString(e[0]).type){case Spicetify.URI.Type.PLAYLIST:case Spicetify.URI.Type.PLAYLIST_V2:return!0}return!1}async function pe(){c=K("starRatings:ratedFolderUri"),m={},d={},y=function(){try{var e=JSON.parse(K("starRatings:playlistUris"));if(e&&"object"==typeof e)return e;throw""}catch{return L("starRatings:playlistUris","{}"),{}}}();let e=null;var t,i,r,a;c?(t=await C(),e=(i=c,t.items.find(e=>"folder"===e.type&&e.uri===i))):(t=await C(),(e=W(t,"Rated"))&&U(c=e.uri)),e?(r=!1,[r,y]=function(e,t){var i={};let r=!1;for(const[a,n]of Object.entries(e))t.items.find(e=>e.uri===n)?i[a]=n:r=!0;return[r,i]}(y,e),a=!1,[a,y]=function(t,e){const i={...t};let r=!1;const a=["0.0","0.5","1.0","1.5","2.0","2.5","3.0","3.5","4.0","4.5","5.0"].filter(e=>!t.hasOwnProperty(e));return e.items.filter(e=>a.includes(e.name)).forEach(e=>{i[e.name]=e.uri,r=!0}),[r,i]}(y,e),(a||r)&&M(y),a=await async function(t){var i=Object.keys(t),r=await Promise.all(i.map(e=>T(t[e]))),a={};for(let e=0;e<i.length;e++)a[i[e]]=r[e];return a}(y),m=function(e){var t,i,r={};for([t,i]of Object.entries(e))for(const a of i)r[a.link]=t;return r}(a),d=function(t,e){const i={};return e.items.filter(e=>Object.values(t).includes(e.uri)).forEach(e=>{i[e.uri]=e.name}),i}(y,e)):0<Object.keys(y).length&&(M(y={}),U(c=""))}(async()=>{var e;document.getElementById("starDratings")||((e=document.createElement("style")).id="starDratings",e.textContent=String.raw`
-  .popup-row::after{content:"";display:table;clear:both}.popup-row .col{display:flex;padding:10px 0;align-items:center}.popup-row .col.description{float:left;padding-right:15px}.popup-row .col.action{float:right;text-align:right}.popup-row .div-title{color:var(--spice-text)}.popup-row .divider{height:2px;border-width:0;background-color:var(--spice-button-disabled)}.popup-row .space{margin-bottom:20px;visibility:hidden}button.checkbox{align-items:center;border:0;border-radius:50%;background-color:rgba(var(--spice-rgb-shadow),.7);color:var(--spice-text);cursor:pointer;display:flex;margin-inline-start:12px;padding:8px}button.checkbox.disabled{color:rgba(var(--spice-rgb-text),.3)}select{color:var(--spice-text);background:rgba(var(--spice-rgb-shadow),.7);border:0;height:32px}::-webkit-scrollbar{width:8px}.login-button{background-color:var(--spice-button);border-radius:8px;border-style:none;box-sizing:border-box;color:var(--spice-text);cursor:pointer;display:inline-block;font-size:14px;font-weight:500;height:40px;line-height:20px;list-style:none;margin:10px;outline:0;padding:5px 10px;position:relative;text-align:center;text-decoration:none;vertical-align:baseline;touch-action:manipulation}.parent-div{display:flex;flex-direction:column;gap:8px}.button-div{margin-top:24px;display:flex;gap:16px;justify-content:flex-end}.cancel-button{background-color:transparent;font-weight:700;border:0;color:var(--spice-text);display:inline-flex;border-radius:500px;font-size:inherit;min-block-size:48px;align-items:center;padding-inline:32px}.cancel-button:hover{transform:scale(1.04)}.ok-button{background-color:var(--spice-button-active);font-weight:700;border:0;color:var(--spice-main);display:inline-flex;border-radius:500px;font-size:inherit;min-block-size:48px;align-items:center;padding-inline:32px}.ok-button:hover{transform:scale(1.04)}
-      `.trim(),document.head.appendChild(e))})()}();
+(async function() {
+        while (!Spicetify.React || !Spicetify.ReactDOM) {
+          await new Promise(resolve => setTimeout(resolve, 10));
+        }
+        var starDratings = (() => {
+  // src/api.tsx
+  function showNotification(text) {
+    Spicetify.showNotification(text);
+  }
+  function getLocalStorageData(key) {
+    return Spicetify.LocalStorage.get(key);
+  }
+  function setLocalStorageData(key, value) {
+    Spicetify.LocalStorage.set(key, value);
+  }
+  async function createPlaylist(name, folderUri) {
+    const options = navigator.platform.startsWith("Linux") && navigator.userAgent.includes("Spotify/1.1.84.716") ? { after: folderUri } : { after: { uri: folderUri } };
+    return await Spicetify.CosmosAsync.post(`https://api.spotify.com/v1/users/${Spicetify.User.getUsername()}/playlists`, {
+      name,
+      ...options
+    });
+  }
+  async function makePlaylistPrivate(playlistUri) {
+    setTimeout(async () => {
+      await Spicetify.CosmosAsync.post(`sp://core-playlist/v1/playlist/${playlistUri}/set-base-permission`, {
+        permission_level: "BLOCKED"
+      });
+    }, 1e3);
+  }
+  async function createFolder(name) {
+    await Spicetify.Platform.RootlistAPI.createFolder(name, { before: "" });
+  }
+  async function getAlbum(uri) {
+    const query = {
+      offset: 0,
+      limit: 450
+    };
+    return await Spicetify.CosmosAsync.get(`https://api.spotify.com/v1/albums/${uri}`, query);
+  }
+  async function getContents() {
+    return await Spicetify.Platform.RootlistAPI.getContents();
+  }
+  async function addTrackToLikedSongs(trackUri) {
+    const isLiked = await Spicetify.Platform.LibraryAPI.contains(trackUri);
+    if (isLiked[0]) {
+      return;
+    }
+    await Spicetify.Platform.LibraryAPI.add({ uris: [trackUri], silent: 0 });
+  }
+  async function addTrackToPlaylist(playlistUri, trackUri) {
+    await Spicetify.Platform.PlaylistAPI.add(playlistUri, [trackUri], { after: 1, before: 0 });
+  }
+  async function removeTrackFromPlaylist(playlistUri, trackUri) {
+    await Spicetify.Platform.PlaylistAPI.remove(playlistUri, [{ uri: trackUri, uid: "" }]);
+  }
+  async function getPlaylistItems(uri) {
+    const result = await Spicetify.CosmosAsync.get(`sp://core-playlist/v1/playlist/${uri}`);
+    return result.items;
+  }
+  async function isAppLaterThan(specifiedVersion) {
+    let appInfo = await Spicetify.CosmosAsync.get("sp://desktop/v1/version");
+    let result = appInfo.version.localeCompare(specifiedVersion, void 0, { numeric: true, sensitivity: "base" });
+    return result === 1;
+  }
+  async function moveTracksBefore(playlistUri, trackUids, beforeUid) {
+    const isV2 = await isAppLaterThan("1.2.5.1006.g22820f93");
+    await Spicetify.Platform.PlaylistAPI.move(
+      playlistUri,
+      trackUids.map((uid) => ({ uid })),
+      { before: isV2 ? { uid: beforeUid } : beforeUid }
+    );
+  }
+  async function moveTracksAfter(playlistUri, trackUids, afterUid) {
+    const isV2 = await isAppLaterThan("1.2.5.1006.g22820f93");
+    await Spicetify.Platform.PlaylistAPI.move(
+      playlistUri,
+      trackUids.map((uid) => ({ uid })),
+      { after: isV2 ? { uid: afterUid } : afterUid }
+    );
+  }
+  async function getTracksWithSameISRC(uri) {
+    const track = await Spicetify.CosmosAsync.get(`https://api.spotify.com/v1/tracks/${uri}`);
+    const isrc = track.external_ids.isrc;
+    const query = {
+      q: `isrc:${isrc}`,
+      type: "track",
+      limit: 50
+    };
+    const response = await Spicetify.CosmosAsync.get(`https://api.spotify.com/v1/search`, query);
+    return response.tracks.items;
+  }
+
+  // src/stars.tsx
+  function findStars(idSuffix) {
+    const starsId = `stars-${idSuffix}`;
+    const stars = document.getElementById(starsId);
+    if (!stars)
+      return null;
+    const starElements = [];
+    for (let i = 1; i <= 5; i++) {
+      const id = `${starsId}-${i}`;
+      const star = document.getElementById(id);
+      const stopFirst = document.getElementById(`${id}-gradient-first`);
+      const stopSecond = document.getElementById(`${id}-gradient-second`);
+      starElements.push([star, stopFirst, stopSecond]);
+    }
+    return [stars, starElements];
+  }
+  function createStar(starsId, n, size) {
+    const xmlns = "http://www.w3.org/2000/svg";
+    const star = document.createElementNS(xmlns, "svg");
+    const id = `${starsId}-${n}`;
+    star.id = id;
+    star.style.minHeight = `${size}px`;
+    star.style.minWidth = `${size}px`;
+    star.setAttributeNS(null, "width", `${size}px`);
+    star.setAttributeNS(null, "height", `${size}px`);
+    star.setAttributeNS(null, "viewBox", `0 0 32 32`);
+    const defs = document.createElementNS(xmlns, "defs");
+    star.append(defs);
+    const gradient = document.createElementNS(xmlns, "linearGradient");
+    defs.append(gradient);
+    gradient.id = `${id}-gradient`;
+    const stopFirst = document.createElementNS(xmlns, "stop");
+    gradient.append(stopFirst);
+    stopFirst.id = `${id}-gradient-first`;
+    stopFirst.setAttributeNS(null, "offset", "50%");
+    stopFirst.setAttributeNS(null, "stop-color", "var(--spice-button-disabled)");
+    const stopSecond = document.createElementNS(xmlns, "stop");
+    gradient.append(stopSecond);
+    stopSecond.id = `${id}-gradient-second`;
+    stopSecond.setAttributeNS(null, "offset", "50%");
+    stopSecond.setAttributeNS(null, "stop-color", "var(--spice-button-disabled)");
+    const path = document.createElementNS(xmlns, "path");
+    star.append(path);
+    path.setAttributeNS(null, "fill", `url(#${gradient.id})`);
+    path.setAttributeNS(
+      null,
+      "d",
+      "M20.388,10.918L32,12.118l-8.735,7.749L25.914,31.4l-9.893-6.088L6.127,31.4l2.695-11.533L0,12.118l11.547-1.2L16.026,0.6L20.388,10.918z"
+    );
+    return [star, stopFirst, stopSecond];
+  }
+  function createStars(trackURI, size) {
+    const stars = document.createElement("span");
+    const id = `stars-${trackURI}`;
+    stars.className = "stars";
+    stars.id = id;
+    stars.style.whiteSpace = "nowrap";
+    stars.style.alignItems = "center";
+    stars.style.display = "flex";
+    const starElements = [];
+    for (let i = 0; i < 5; i++) {
+      const [star, stopFirst, stopSecond] = createStar(id, i + 1, size);
+      stars.append(star);
+      starElements.push([star, stopFirst, stopSecond]);
+    }
+    return [stars, starElements];
+  }
+  function setRating(starElements, rating) {
+    const halfStars = rating /= 0.5;
+    for (let i = 0; i < 5; i++) {
+      const stopFirst = starElements[i][1];
+      const stopSecond = starElements[i][2];
+      stopFirst.setAttributeNS(null, "stop-color", "var(--spice-button-disabled)");
+      stopSecond.setAttributeNS(null, "stop-color", "var(--spice-button-disabled)");
+    }
+    for (let i = 0; i < halfStars; i++) {
+      const j = Math.floor(i / 2);
+      const stopFirst = starElements[j][1];
+      const stopSecond = starElements[j][2];
+      if (i % 2 === 0) {
+        stopFirst.setAttributeNS(null, "stop-color", "var(--spice-button)");
+      } else {
+        stopSecond.setAttributeNS(null, "stop-color", "var(--spice-button)");
+      }
+    }
+  }
+  function getMouseoverRating(settings3, star, i) {
+    const rect = star.getBoundingClientRect();
+    const offset = event.clientX - rect.left;
+    const half = offset > 8 || !settings3.halfStarRatings;
+    const zeroStars = i === 0 && offset < 3;
+    let rating = i + 1;
+    if (!half)
+      rating -= 0.5;
+    if (zeroStars) {
+      rating -= settings3.halfStarRatings ? 0.5 : 1;
+    }
+    return rating;
+  }
+
+  // src/settings.tsx
+  function getSettings() {
+    const defaultSettings = {
+      halfStarRatings: true,
+      likeThreshold: "4.0",
+      enableKeyboardShortcuts: true,
+      showPlaylistStars: true,
+      nowPlayingStarsPosition: "left",
+      skipThreshold: "disabled",
+      syncDuplicateSongs: false
+    };
+    settings = {};
+    try {
+      const parsed = JSON.parse(getLocalStorageData("starRatings:settings"));
+      if (parsed && typeof parsed === "object") {
+        settings = parsed;
+      } else {
+        throw "";
+      }
+    } catch {
+      setLocalStorageData("starRatings:settings", defaultSettings);
+      return defaultSettings;
+    }
+    let modified = false;
+    for (const key of Object.keys(defaultSettings)) {
+      if (!settings.hasOwnProperty(key)) {
+        settings[key] = defaultSettings[key];
+        modified = true;
+      }
+    }
+    if (modified) {
+      setLocalStorageData("starRatings:settings", settings);
+    }
+    return settings;
+  }
+  function saveSettings(settings3) {
+    setLocalStorageData("starRatings:settings", JSON.stringify(settings3));
+  }
+  function getPlaylistUris() {
+    try {
+      const parsed = JSON.parse(getLocalStorageData("starRatings:playlistUris"));
+      if (parsed && typeof parsed === "object") {
+        return parsed;
+      }
+      throw "";
+    } catch {
+      setLocalStorageData("starRatings:playlistUris", `{}`);
+      return {};
+    }
+  }
+  function savePlaylistUris(playlistUris2) {
+    setLocalStorageData("starRatings:playlistUris", JSON.stringify(playlistUris2));
+  }
+  function getRatedFolderUri() {
+    return getLocalStorageData("starRatings:ratedFolderUri");
+  }
+  function saveRatedFolderUri(ratedFolderUri2) {
+    setLocalStorageData("starRatings:ratedFolderUri", ratedFolderUri2);
+  }
+
+  // src/settings-ui.tsx
+  var React = Spicetify.React;
+  function CheckboxIcon() {
+    return /* @__PURE__ */ React.createElement("svg", {
+      width: 16,
+      height: 16,
+      viewbox: "0 0 16 16",
+      fill: "currentColor",
+      dangerouslySetInnerHTML: {
+        __html: Spicetify.SVGIcons.check
+      }
+    });
+  }
+  function CheckboxItem({ settings: settings3, name, field, onclick }) {
+    let [value, setValue] = Spicetify.React.useState(settings3[field]);
+    const buttonClass = value ? "checkbox" : "checkbox disabled";
+    function handleOnClick() {
+      let state = !value;
+      settings3[field] = state;
+      setValue(state);
+      saveSettings(settings3);
+      if (onclick)
+        onclick();
+    }
+    return /* @__PURE__ */ React.createElement("div", {
+      className: "popup-row"
+    }, /* @__PURE__ */ React.createElement("label", {
+      className: "col description"
+    }, name), /* @__PURE__ */ React.createElement("div", {
+      className: "col action"
+    }, /* @__PURE__ */ React.createElement("button", {
+      className: buttonClass,
+      onClick: handleOnClick
+    }, /* @__PURE__ */ React.createElement(CheckboxIcon, null))));
+  }
+  function DropdownItem({ settings: settings3, name, field, options, onclick }) {
+    const [value, setValue] = Spicetify.React.useState(settings3[field]);
+    function handleOnChange(event2) {
+      setValue(event2.target.value);
+      settings3[field] = event2.target.value;
+      saveSettings(settings3);
+      if (onclick)
+        onclick();
+    }
+    const optionElements = [];
+    for (const [optionName, optionValue] of Object.entries(options))
+      optionElements.push(/* @__PURE__ */ React.createElement("option", {
+        value: optionValue
+      }, optionName));
+    return /* @__PURE__ */ React.createElement("div", {
+      className: "popup-row"
+    }, /* @__PURE__ */ React.createElement("label", {
+      className: "col description"
+    }, name), /* @__PURE__ */ React.createElement("div", {
+      className: "col action"
+    }, /* @__PURE__ */ React.createElement("select", {
+      value,
+      onChange: handleOnChange
+    }, optionElements)));
+  }
+  function KeyboardShortcutDescription({ label, numberKey }) {
+    return /* @__PURE__ */ React.createElement("li", {
+      className: "main-keyboardShortcutsHelpModal-sectionItem"
+    }, /* @__PURE__ */ React.createElement("span", {
+      className: "Type__TypeElement-goli3j-0 ipKmGr main-keyboardShortcutsHelpModal-sectionItemName"
+    }, label), /* @__PURE__ */ React.createElement("kbd", {
+      className: "Type__TypeElement-goli3j-0 ipKmGr main-keyboardShortcutsHelpModal-key"
+    }, "Ctrl"), /* @__PURE__ */ React.createElement("kbd", {
+      className: "Type__TypeElement-goli3j-0 ipKmGr main-keyboardShortcutsHelpModal-key"
+    }, "Alt"), /* @__PURE__ */ React.createElement("kbd", {
+      className: "Type__TypeElement-goli3j-0 ipKmGr main-keyboardShortcutsHelpModal-key"
+    }, numberKey));
+  }
+  function Heading({ value }) {
+    return /* @__PURE__ */ React.createElement("h2", {
+      className: "Type__TypeElement-goli3j-0 bcTfIx main-keyboardShortcutsHelpModal-sectionHeading"
+    }, value);
+  }
+  function Settings({
+    settings: settings3,
+    registerKeyboardShortcuts,
+    deregisterKeyboardShortcuts,
+    updateTracklist: updateTracklist2,
+    restoreTracklist: restoreTracklist2,
+    redrawNowPlayingStars
+  }) {
+    function handleEnableKeyboardShortcutsCheckboxClick() {
+      if (settings3.enableKeyboardShortcuts)
+        registerKeyboardShortcuts();
+      else
+        deregisterKeyboardShortcuts();
+    }
+    function handleShowPlaylistStarsCheckboxClick() {
+      if (settings3.showPlaylistStars)
+        updateTracklist2();
+      else
+        restoreTracklist2();
+    }
+    function hanleNowPlayingStarsPositionDropdownClick() {
+      redrawNowPlayingStars();
+    }
+    return /* @__PURE__ */ React.createElement("div", null, /* @__PURE__ */ React.createElement(Heading, {
+      value: "Settings"
+    }), /* @__PURE__ */ React.createElement(CheckboxItem, {
+      settings: settings3,
+      name: "Half star ratings",
+      field: "halfStarRatings"
+    }), /* @__PURE__ */ React.createElement(CheckboxItem, {
+      settings: settings3,
+      name: "Enable keyboard shortcuts",
+      field: "enableKeyboardShortcuts",
+      onclick: handleEnableKeyboardShortcutsCheckboxClick
+    }), /* @__PURE__ */ React.createElement(CheckboxItem, {
+      settings: settings3,
+      name: "Show playlist stars",
+      field: "showPlaylistStars",
+      onclick: handleShowPlaylistStarsCheckboxClick
+    }), /* @__PURE__ */ React.createElement(DropdownItem, {
+      settings: settings3,
+      name: "Auto-like/dislike threshold",
+      field: "likeThreshold",
+      options: {
+        Disabled: "disabled",
+        "3.0": "3.0",
+        "3.5": "3.5",
+        "4.0": "4.0",
+        "4.5": "4.5",
+        "5.0": "5.0"
+      }
+    }), /* @__PURE__ */ React.createElement(DropdownItem, {
+      settings: settings3,
+      name: "Now playing stars position",
+      field: "nowPlayingStarsPosition",
+      options: {
+        Left: "left",
+        Right: "right"
+      },
+      onclick: hanleNowPlayingStarsPositionDropdownClick
+    }), /* @__PURE__ */ React.createElement(DropdownItem, {
+      settings: settings3,
+      name: "Skip threshold",
+      field: "skipThreshold",
+      options: {
+        Disabled: "disabled",
+        "0.0": "0.0",
+        "0.5": "0.5",
+        "1.0": "1.0",
+        "1.5": "1.5",
+        "2.0": "2.0",
+        "2.5": "2.5",
+        "3.0": "3.0",
+        "3.5": "3.5",
+        "4.0": "4.0",
+        "4.5": "4.5"
+      }
+    }), /* @__PURE__ */ React.createElement(CheckboxItem, {
+      settings: settings3,
+      name: /* @__PURE__ */ React.createElement(React.Fragment, null, "Sync duplicate songs with same rating", /* @__PURE__ */ React.createElement("br", null), "(Does not apply to songs that have already been rated)"),
+      field: "syncDuplicateSongs"
+    }), /* @__PURE__ */ React.createElement(Heading, {
+      value: "Keyboard Shortcuts"
+    }), /* @__PURE__ */ React.createElement("ul", null, /* @__PURE__ */ React.createElement(KeyboardShortcutDescription, {
+      label: "Rate current track 0.5 stars",
+      numberKey: "1"
+    }), /* @__PURE__ */ React.createElement(KeyboardShortcutDescription, {
+      label: "Rate current track 1 star",
+      numberKey: "2"
+    }), /* @__PURE__ */ React.createElement(KeyboardShortcutDescription, {
+      label: "Rate current track 1.5 stars",
+      numberKey: "3"
+    }), /* @__PURE__ */ React.createElement(KeyboardShortcutDescription, {
+      label: "Rate current track 2 stars",
+      numberKey: "4"
+    }), /* @__PURE__ */ React.createElement(KeyboardShortcutDescription, {
+      label: "Rate current track 2.5 stars",
+      numberKey: "5"
+    }), /* @__PURE__ */ React.createElement(KeyboardShortcutDescription, {
+      label: "Rate current track 3 stars",
+      numberKey: "6"
+    }), /* @__PURE__ */ React.createElement(KeyboardShortcutDescription, {
+      label: "Rate current track 3.5 stars",
+      numberKey: "7"
+    }), /* @__PURE__ */ React.createElement(KeyboardShortcutDescription, {
+      label: "Rate current track 4 stars",
+      numberKey: "8"
+    }), /* @__PURE__ */ React.createElement(KeyboardShortcutDescription, {
+      label: "Rate current track 4.5 stars",
+      numberKey: "9"
+    }), /* @__PURE__ */ React.createElement(KeyboardShortcutDescription, {
+      label: "Rate current track 5 stars",
+      numberKey: "0"
+    })));
+  }
+
+  // src/sort-modal.tsx
+  var React2 = Spicetify.React;
+  function Button({ name, className, onButtonClick }) {
+    return /* @__PURE__ */ React2.createElement("button", {
+      className,
+      onClick: onButtonClick
+    }, name);
+  }
+  function SortModal({ onClickCancel, onClickOK }) {
+    return /* @__PURE__ */ React2.createElement("div", {
+      className: "parent-div"
+    }, /* @__PURE__ */ React2.createElement("p", null, "This will modify the ", /* @__PURE__ */ React2.createElement("b", null, "Custom order"), " of the playlist."), /* @__PURE__ */ React2.createElement("div", {
+      className: "button-div"
+    }, /* @__PURE__ */ React2.createElement(Button, {
+      name: "Cancel",
+      className: "cancel-button",
+      onButtonClick: onClickCancel
+    }), /* @__PURE__ */ React2.createElement(Button, {
+      name: "Sort",
+      className: "ok-button",
+      onButtonClick: onClickOK
+    })));
+  }
+
+  // src/ratings.tsx
+  function findFolderByUri(contents, uri) {
+    return contents.items.find((item) => item.type === "folder" && item.uri === uri);
+  }
+  function findFolderByName(contents, name) {
+    return contents.items.find((item) => item.type === "folder" && item.name === name);
+  }
+  function removePlaylistUris(playlistUris2, ratedFolder) {
+    const newPlaylistUris = {};
+    let changed = false;
+    for (const [rating, playlistUri] of Object.entries(playlistUris2)) {
+      if (ratedFolder.items.find((item) => item.uri === playlistUri))
+        newPlaylistUris[rating] = playlistUri;
+      else
+        changed = true;
+    }
+    return [changed, newPlaylistUris];
+  }
+  function addPlaylistUris(playlistUris2, ratedFolder) {
+    const newPlaylistUris = { ...playlistUris2 };
+    let changed = false;
+    const ratings2 = ["0.0", "0.5", "1.0", "1.5", "2.0", "2.5", "3.0", "3.5", "4.0", "4.5", "5.0"];
+    const unmappedRatings = ratings2.filter((rating) => !playlistUris2.hasOwnProperty(rating));
+    ratedFolder.items.filter((item) => unmappedRatings.includes(item.name)).forEach((item) => {
+      newPlaylistUris[item.name] = item.uri;
+      changed = true;
+    });
+    return [changed, newPlaylistUris];
+  }
+  function getPlaylistNames(playlistUris2, ratedFolder) {
+    const playlistNames2 = {};
+    ratedFolder.items.filter((item) => Object.values(playlistUris2).includes(item.uri)).forEach((item) => {
+      playlistNames2[item.uri] = item.name;
+    });
+    return playlistNames2;
+  }
+  async function getAllPlaylistItems(playlistUris2) {
+    const ratings2 = Object.keys(playlistUris2);
+    const allPlaylistItemsArray = await Promise.all(ratings2.map((rating) => getPlaylistItems(playlistUris2[rating])));
+    const allPlaylistItems = {};
+    for (let i = 0; i < ratings2.length; i++)
+      allPlaylistItems[ratings2[i]] = allPlaylistItemsArray[i];
+    return allPlaylistItems;
+  }
+  function getRatingsByTrack(allPlaylistItems) {
+    const ratings2 = {};
+    for (const [rating, tracks] of Object.entries(allPlaylistItems)) {
+      for (const track of tracks) {
+        const trackUri = track.link;
+        ratings2[trackUri] = rating;
+      }
+    }
+    return ratings2;
+  }
+  function getAlbumRating(ratings2, album2) {
+    console.log("album is:", album2);
+    if (!album2)
+      return "0.0";
+    const items = album2.tracks.items;
+    let sumRatings = 0;
+    let numRatings = 0;
+    for (const item of items) {
+      const trackUri = item.uri;
+      const rating = parseFloat(ratings2[trackUri]);
+      if (!rating)
+        continue;
+      sumRatings += rating;
+      numRatings += 1;
+    }
+    let averageRating = 0;
+    if (numRatings > 0)
+      averageRating = sumRatings / numRatings;
+    averageRating = Math.round(averageRating * 2) / 2;
+    return averageRating.toFixed(1);
+  }
+  async function sortPlaylistByRating(playlistUri, ratings2) {
+    const ratingKeys = ["5.0", "4.5", "4.0", "3.5", "3.0", "2.5", "2.0", "1.5", "1.0", "0.5", "0.0"];
+    const items = await getPlaylistItems(playlistUri);
+    if (items.length === 0)
+      return;
+    const ratingToUids = {};
+    for (const rating of ratingKeys)
+      ratingToUids[rating] = [];
+    for (const item of items) {
+      let rating = ratings2[item.link] ?? 0;
+      if (typeof rating === "number")
+        rating = rating.toFixed(1);
+      ratingToUids[rating].push(item.rowId);
+    }
+    function getHighestRatedUid(ratingToUids2) {
+      for (const rating of ratingKeys) {
+        if (ratingToUids2[rating].length > 0)
+          return ratingToUids2[rating][0];
+      }
+      return null;
+    }
+    let previousIterationLastUid = getHighestRatedUid(ratingToUids);
+    const firstUid = items[0].rowId;
+    const isFirstItemHighestRated = previousIterationLastUid === firstUid;
+    let isFirstIteration = true;
+    for (const rating of ratingKeys) {
+      if (ratingToUids[rating].length === 0)
+        continue;
+      if (!isFirstItemHighestRated && isFirstIteration) {
+        await moveTracksBefore(playlistUri, ratingToUids[rating], previousIterationLastUid);
+      } else {
+        await moveTracksAfter(playlistUri, ratingToUids[rating], previousIterationLastUid);
+      }
+      isFirstIteration = false;
+      previousIterationLastUid = ratingToUids[rating].slice(-1)[0];
+    }
+  }
+
+  // src/css/css.ts
+  var tracklistColumnCss = [
+    null,
+    null,
+    null,
+    null,
+    "[index] 16px [first] 4fr [var1] 2fr [var2] 1fr [last] minmax(120px,1fr)",
+    "[index] 16px [first] 6fr [var1] 4fr [var2] 3fr [var3] 2fr [last] minmax(120px,1fr)",
+    "[index] 16px [first] 6fr [var1] 4fr [var2] 3fr [var3] minmax(120px,2fr) [var3] 2fr [last] minmax(120px,1fr)"
+  ];
+
+  // src/utils/utils.ts
+  function getTracklistTrackUri(tracklistElement) {
+    let values = Object.values(tracklistElement);
+    if (!values)
+      return null;
+    const searchFrom = values[0]?.pendingProps?.children[0]?.props?.children;
+    return searchFrom?.props?.uri || searchFrom?.props?.children?.props?.uri || searchFrom?.props?.children?.props?.children?.props?.uri || searchFrom[0]?.props?.uri;
+  }
+  function isAlbumPage() {
+    const pathname = Spicetify.Platform.History.location.pathname;
+    const matches = pathname.match(/album\/(.*)/);
+    if (!matches)
+      return null;
+    return matches[1];
+  }
+  function trackUriToTrackId(trackUri) {
+    return trackUri.replace("spotify:track:", "");
+  }
+  var getNowPlayingTrackUri = () => {
+    return Spicetify.Player.data.item.uri;
+  };
+
+  // src/app.tsx
+  var settings2 = null;
+  var ratedFolderUri = null;
+  var ratings = {};
+  var playlistNames = {};
+  var playlistUris = {};
+  var originalTracklistHeaderCss = null;
+  var originalTracklistTrackCss = null;
+  var oldMainElement = null;
+  var mainElement = null;
+  var mainElementObserver = null;
+  var tracklists = [];
+  var oldTracklists = [];
+  var oldNowPlayingWidget = null;
+  var nowPlayingWidget = null;
+  var oldPlayButton = null;
+  var playButton = null;
+  var albumId = null;
+  var album = null;
+  var albumStarData = null;
+  var nowPlayingWidgetStarData = null;
+  var clickListenerRunning = false;
+  var ratingsLoading = false;
+  var isSorting = false;
+  var PLAYLIST_SIZE_LIMIT = 8e3;
+  function updateAlbumRating() {
+    const averageRating = getAlbumRating(ratings, album);
+    setRating(albumStarData[1], averageRating);
+  }
+  async function handleRemoveRating(trackUri, rating) {
+    delete ratings[trackUri];
+    const playlistUri = playlistUris[rating];
+    const playlistName = playlistNames[playlistUri];
+    await removeTrackFromPlaylist(playlistUri, trackUri);
+    showNotification(`Removed from ${playlistName}`);
+  }
+  async function handleSetRating(trackUri, oldRating, newRating, allowLike = true) {
+    try {
+      ratings[trackUri] = newRating;
+      if (oldRating) {
+        const oldRatingAsString = oldRating;
+        const playlistUri2 = playlistUris[oldRatingAsString];
+        await removeTrackFromPlaylist(playlistUri2, trackUri);
+      }
+      if (!ratedFolderUri) {
+        await createFolder("Rated");
+        const contents = await getContents();
+        const ratedFolder = findFolderByName(contents, "Rated");
+        ratedFolderUri = ratedFolder.uri;
+        saveRatedFolderUri(ratedFolderUri);
+      }
+      let playlistUri = playlistUris[newRating];
+      let playlistName = newRating;
+      if (!playlistUri) {
+        playlistUri = await createPlaylist(playlistName, ratedFolderUri);
+        await makePlaylistPrivate(playlistUri);
+        playlistUris[newRating] = playlistUri;
+        savePlaylistUris(playlistUris);
+        playlistNames[playlistUri] = playlistName;
+      } else {
+        const items = await getPlaylistItems(playlistUri);
+        if (items.length >= PLAYLIST_SIZE_LIMIT) {
+          let suffix = 1;
+          let newPlaylistUri;
+          while (true) {
+            try {
+              const newPlaylistName = `${newRating}(${suffix})`;
+              newPlaylistUri = await createPlaylist(newPlaylistName, ratedFolderUri);
+              await makePlaylistPrivate(newPlaylistUri);
+              break;
+            } catch (e) {
+              suffix++;
+              if (suffix > 100) {
+                throw new Error("Unable to create overflow playlist");
+              }
+            }
+          }
+          playlistUri = newPlaylistUri;
+          playlistUris[newRating] = newPlaylistUri;
+          savePlaylistUris(playlistUris);
+          playlistNames[newPlaylistUri] = `${newRating}(${suffix})`;
+        }
+      }
+      await addTrackToPlaylist(playlistUri, trackUri);
+      const displayName = playlistNames[playlistUri];
+      showNotification((oldRating ? "Moved" : "Added") + ` to ${displayName}`);
+      if (settings2.likeThreshold !== "disabled" && allowLike) {
+        const threshold = parseFloat(settings2.likeThreshold);
+        const ratingValue = parseFloat(newRating);
+        if (ratingValue >= threshold) {
+          await addTrackToLikedSongs(trackUri);
+        }
+      }
+    } catch (error) {
+      console.error("Error in handleSetRating:", error);
+      showNotification("Error updating rating: " + (error.message || "Unknown error"));
+    }
+  }
+  function getClickListener(i, ratingOverride, starData, getTrackUri) {
+    return () => {
+      if (clickListenerRunning || ratingsLoading || isSorting)
+        return;
+      clickListenerRunning = true;
+      const [stars, starElements] = starData;
+      const star = starElements[i][0];
+      const trackUri = getTrackUri();
+      const oldRating = ratings[trackUri];
+      let newRating = ratingOverride !== null ? ratingOverride : getMouseoverRating(settings2, star, i).toFixed(1);
+      let promise = null;
+      let displayRating = null;
+      if (oldRating === newRating) {
+        displayRating = 0;
+        promise = handleRemoveRating(trackUri, newRating);
+        if (settings2.syncDuplicateSongs) {
+          (async () => {
+            try {
+              const tracksWithSameISRC = await getTracksWithSameISRC(trackUri.substring(14));
+              for (const track of tracksWithSameISRC) {
+                const trackUri2 = track.uri;
+                if (trackUri2 in ratings) {
+                  await handleRemoveRating(trackUri2, ratings[trackUri2]);
+                }
+              }
+            } catch (error) {
+              console.error(error);
+            }
+          })();
+        }
+      } else {
+        displayRating = newRating;
+        promise = handleSetRating(trackUri, oldRating, newRating);
+        if (settings2.likeThreshold !== "disabled") {
+          if (newRating >= parseFloat(settings2.likeThreshold))
+            addTrackToLikedSongs(trackUri);
+        }
+        if (settings2.syncDuplicateSongs) {
+          (async () => {
+            try {
+              const tracksWithSameISRC = await getTracksWithSameISRC(trackUri.substring(14));
+              for (const track of tracksWithSameISRC) {
+                const trackUri2 = track.uri;
+                await handleSetRating(trackUri2, ratings[trackUri2], newRating, false);
+              }
+            } catch (error) {
+              console.error(error);
+            }
+          })();
+        }
+      }
+      promise.finally(() => {
+        let tracklistStarData = findStars(trackUriToTrackId(trackUri));
+        if (tracklistStarData) {
+          setRating(tracklistStarData[1], displayRating);
+          tracklistStarData[0].style.visibility = oldRating === newRating ? "hidden" : "visible";
+        }
+        updateNowPlayingWidget();
+        clickListenerRunning = false;
+      });
+    };
+  }
+  function getRegisterKeyboardShortcuts(keys) {
+    return () => {
+      for (const [rating, key] of Object.entries(keys)) {
+        Spicetify.Keyboard.registerShortcut(
+          {
+            key,
+            ctrl: true,
+            alt: true
+          },
+          getClickListener(0, parseFloat(rating), nowPlayingWidgetStarData, getNowPlayingTrackUri)
+        );
+      }
+    };
+  }
+  function getDeregisterKeyboardShortcuts(keys) {
+    return () => {
+      for (const key of Object.values(keys)) {
+        Spicetify.Keyboard._deregisterShortcut({
+          key,
+          ctrl: true,
+          alt: true
+        });
+      }
+    };
+  }
+  function addStarsListeners(starData, getTrackUri) {
+    function getCurrentRating(trackUri) {
+      return ratings[trackUri] ?? 0;
+    }
+    const [stars, starElements] = starData;
+    stars.addEventListener("mouseout", function() {
+      setRating(starElements, getCurrentRating(getTrackUri()));
+    });
+    for (let i = 0; i < 5; i++) {
+      const star = starElements[i][0];
+      star.addEventListener("mousemove", function() {
+        const rating = getMouseoverRating(settings2, star, i);
+        setRating(starElements, rating);
+      });
+      star.addEventListener("click", getClickListener(i, null, starData, getTrackUri));
+    }
+  }
+  function restoreTracklist() {
+    const tracklistHeaders = document.querySelectorAll(".main-trackList-trackListHeaderRow");
+    tracklistHeaders.forEach((tracklistHeader) => {
+      tracklistHeader.style["grid-template-columns"] = originalTracklistHeaderCss;
+    });
+    for (const tracklist of Array.from(tracklists)) {
+      const tracks = tracklist.getElementsByClassName("main-trackList-trackListRow");
+      for (const track of Array.from(tracks)) {
+        let ratingColumn = track.querySelector(".starRatings");
+        if (!ratingColumn)
+          continue;
+        track.style["grid-template-columns"] = originalTracklistTrackCss;
+        ratingColumn.remove();
+        let lastColumn = track.querySelector(".main-trackList-rowSectionEnd");
+        let colIndexInt = parseInt(lastColumn.getAttribute("aria-colindex"));
+        lastColumn.setAttribute("aria-colindex", (colIndexInt - 1).toString());
+      }
+    }
+  }
+  function updateTracklist() {
+    if (!settings2.showPlaylistStars)
+      return;
+    oldTracklists = tracklists;
+    tracklists = Array.from(document.querySelectorAll(".main-trackList-indexable"));
+    let tracklistsChanged = tracklists.length !== oldTracklists.length;
+    for (let i = 0; i < tracklists.length; i++) {
+      if (!tracklists[i].isEqualNode(oldTracklists[i]))
+        tracklistsChanged = true;
+    }
+    if (tracklistsChanged) {
+      originalTracklistHeaderCss = null;
+      originalTracklistTrackCss = null;
+    }
+    createStarsForTracklists(tracklists);
+  }
+  function createStarsForTracklists(tracklists2) {
+    let newTracklistHeaderCss = null;
+    const tracklistHeaders = document.querySelectorAll(".main-trackList-trackListHeaderRow");
+    tracklistHeaders.forEach((tracklistHeader) => {
+      let lastColumn = tracklistHeader.querySelector(".main-trackList-rowSectionEnd");
+      let colIndexInt = parseInt(lastColumn.getAttribute("aria-colindex"));
+      if (!originalTracklistHeaderCss)
+        originalTracklistHeaderCss = getComputedStyle(tracklistHeader).gridTemplateColumns;
+      if (originalTracklistHeaderCss && tracklistColumnCss[colIndexInt]) {
+        tracklistHeader.style["grid-template-columns"] = tracklistColumnCss[colIndexInt];
+        newTracklistHeaderCss = tracklistColumnCss[colIndexInt];
+      }
+    });
+    for (const tracklist of tracklists2) {
+      const tracks = tracklist.getElementsByClassName("main-trackList-trackListRow");
+      for (const track of tracks) {
+        const getHeart = () => {
+          return track.getElementsByClassName("main-addButton-button")[0] ?? track.querySelector(".main-trackList-rowHeartButton") ?? track.querySelector("button[class*='buttonTertiary-iconOnly']") ?? track.querySelector("button[aria-label='Add to playlist']");
+        };
+        const hasStars = track.getElementsByClassName("stars").length > 0;
+        const trackUri = getTracklistTrackUri(track);
+        const isTrack = trackUri.includes("track");
+        let ratingColumn = track.querySelector(".starRatings");
+        if (!ratingColumn) {
+          let lastColumn = track.querySelector(".main-trackList-rowSectionEnd");
+          let colIndexInt = parseInt(lastColumn.getAttribute("aria-colindex"));
+          lastColumn.setAttribute("aria-colindex", (colIndexInt + 1).toString());
+          ratingColumn = document.createElement("div");
+          ratingColumn.setAttribute("aria-colindex", colIndexInt.toString());
+          ratingColumn.role = "gridcell";
+          ratingColumn.style.display = "flex";
+          ratingColumn.classList.add("main-trackList-rowSectionVariable");
+          ratingColumn.classList.add("starRatings");
+          track.insertBefore(ratingColumn, lastColumn);
+          if (!originalTracklistTrackCss)
+            originalTracklistTrackCss = getComputedStyle(track).gridTemplateColumns;
+          if (tracklistColumnCss[colIndexInt])
+            track.style["grid-template-columns"] = newTracklistHeaderCss ? newTracklistHeaderCss : tracklistColumnCss[colIndexInt];
+        }
+        if (!trackUri || hasStars || !isTrack)
+          continue;
+        const starData = createStars(trackUriToTrackId(trackUri), 16);
+        const stars = starData[0];
+        const starElements = starData[1];
+        const currentRating = ratings[trackUri] ?? 0;
+        ratingColumn.appendChild(stars);
+        setRating(starElements, currentRating);
+        addStarsListeners(
+          starData,
+          () => {
+            return trackUri;
+          },
+          getHeart
+        );
+        stars.style.visibility = typeof ratings[trackUri] !== "undefined" ? "visible" : "hidden";
+        track.addEventListener("mouseover", () => {
+          stars.style.visibility = "visible";
+        });
+        track.addEventListener("mouseout", () => {
+          stars.style.visibility = typeof ratings[trackUri] !== "undefined" ? "visible" : "hidden";
+        });
+      }
+    }
+  }
+  async function observerCallback(keys) {
+    oldMainElement = mainElement;
+    mainElement = document.querySelector("main");
+    if (mainElement && !mainElement.isEqualNode(oldMainElement)) {
+      if (oldMainElement) {
+        mainElementObserver.disconnect();
+      }
+      updateTracklist();
+      mainElementObserver.observe(mainElement, {
+        childList: true,
+        subtree: true
+      });
+    }
+    oldNowPlayingWidget = nowPlayingWidget;
+    let selector = settings2.nowPlayingStarsPosition === "left" ? ".main-nowPlayingWidget-nowPlaying .main-trackInfo-container" : ".main-nowPlayingBar-right div";
+    nowPlayingWidget = document.querySelector(selector);
+    if (nowPlayingWidget && !nowPlayingWidget.isEqualNode(oldNowPlayingWidget)) {
+      nowPlayingWidgetStarData = createStars("now-playing", 16);
+      nowPlayingWidgetStarData[0].style.marginLeft = "8px";
+      nowPlayingWidgetStarData[0].style.marginRight = "8px";
+      if (settings2.nowPlayingStarsPosition === "left")
+        nowPlayingWidget.after(nowPlayingWidgetStarData[0]);
+      else
+        nowPlayingWidget.prepend(nowPlayingWidgetStarData[0]);
+      addStarsListeners(nowPlayingWidgetStarData, getNowPlayingTrackUri);
+      updateNowPlayingWidget();
+      if (settings2.enableKeyboardShortcuts) {
+        getRegisterKeyboardShortcuts(keys)();
+      }
+    }
+    oldPlayButton = playButton;
+    playButton = document.querySelector(".main-actionBar-ActionBar .ix_8kg3iUb9VS5SmTnBY");
+    if (playButton && !playButton.isEqualNode(oldPlayButton) && isAlbumPage() !== null) {
+      albumStarData = createStars("album", 32);
+      playButton.after(albumStarData[0]);
+      await updateAlbumStars();
+    }
+  }
+  async function updateAlbumStars() {
+    if (!albumStarData)
+      return;
+    albumId = isAlbumPage();
+    albumStarData[0].style.display = albumId ? "flex" : "none";
+    console.log("albumId is:", albumId);
+    if (!albumId)
+      return;
+    album = await getAlbum(albumId);
+    updateAlbumRating();
+  }
+  function updateNowPlayingWidget() {
+    if (!nowPlayingWidgetStarData)
+      return;
+    function getTrackUri() {
+      return Spicetify.Player.data.item.uri;
+    }
+    ;
+    const trackUri = getTrackUri();
+    const isTrack = trackUri.includes("track");
+    nowPlayingWidgetStarData[0].style.display = isTrack ? "flex" : "none";
+    const currentRating = ratings[trackUri] ?? 0;
+    setRating(nowPlayingWidgetStarData[1], currentRating);
+  }
+  function shouldAddContextMenuOnFolders(uri) {
+    let uriObj = Spicetify.URI.fromString(uri[0]);
+    return uriObj.type === Spicetify.URI.Type.FOLDER;
+  }
+  function shouldAddContextMenuOnPlaylists(uri) {
+    let uriObj = Spicetify.URI.fromString(uri[0]);
+    switch (uriObj.type) {
+      case Spicetify.URI.Type.PLAYLIST:
+      case Spicetify.URI.Type.PLAYLIST_V2:
+        return true;
+    }
+    return false;
+  }
+  async function loadRatings() {
+    ratedFolderUri = getRatedFolderUri();
+    ratings = {};
+    playlistNames = {};
+    playlistUris = getPlaylistUris();
+    let ratedFolder = null;
+    if (ratedFolderUri) {
+      const contents = await getContents();
+      ratedFolder = findFolderByUri(contents, ratedFolderUri);
+    } else {
+      const contents = await getContents();
+      ratedFolder = findFolderByName(contents, "Rated");
+      if (ratedFolder) {
+        ratedFolderUri = ratedFolder.uri;
+        saveRatedFolderUri(ratedFolderUri);
+      }
+    }
+    if (ratedFolder) {
+      let playlistUrisRemoved = false;
+      [playlistUrisRemoved, playlistUris] = removePlaylistUris(playlistUris, ratedFolder);
+      let playlistUrisAdded = false;
+      [playlistUrisAdded, playlistUris] = addPlaylistUris(playlistUris, ratedFolder);
+      if (playlistUrisAdded || playlistUrisRemoved)
+        savePlaylistUris(playlistUris);
+      const allPlaylistItems = await getAllPlaylistItems(playlistUris);
+      ratings = getRatingsByTrack(allPlaylistItems);
+      playlistNames = getPlaylistNames(playlistUris, ratedFolder);
+    } else if (Object.keys(playlistUris).length > 0) {
+      playlistUris = {};
+      savePlaylistUris(playlistUris);
+      ratedFolderUri = "";
+      saveRatedFolderUri(ratedFolderUri);
+    }
+  }
+  async function main() {
+    while (!Spicetify?.showNotification) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    settings2 = getSettings();
+    saveSettings(settings2);
+    await loadRatings();
+    const keys = {
+      "5.0": Spicetify.Keyboard.KEYS.NUMPAD_0,
+      "0.5": Spicetify.Keyboard.KEYS.NUMPAD_1,
+      "1.0": Spicetify.Keyboard.KEYS.NUMPAD_2,
+      "1.5": Spicetify.Keyboard.KEYS.NUMPAD_3,
+      "2.0": Spicetify.Keyboard.KEYS.NUMPAD_4,
+      "2.5": Spicetify.Keyboard.KEYS.NUMPAD_5,
+      "3.0": Spicetify.Keyboard.KEYS.NUMPAD_6,
+      "3.5": Spicetify.Keyboard.KEYS.NUMPAD_7,
+      "4.0": Spicetify.Keyboard.KEYS.NUMPAD_8,
+      "4.5": Spicetify.Keyboard.KEYS.NUMPAD_9
+    };
+    const registerKeyboardShortcuts = getRegisterKeyboardShortcuts(keys);
+    const deregisterKeyboardShortcuts = getDeregisterKeyboardShortcuts(keys);
+    const redrawNowPlayingStars = () => {
+      if (nowPlayingWidgetStarData)
+        nowPlayingWidgetStarData[0].remove();
+      nowPlayingWidget = null;
+      observerCallback(keys);
+    };
+    new Spicetify.Menu.Item("Star Ratings", true, () => {
+      Spicetify.PopupModal.display({
+        title: "Star Ratings",
+        content: Settings({
+          settings: settings2,
+          registerKeyboardShortcuts,
+          deregisterKeyboardShortcuts,
+          updateTracklist,
+          restoreTracklist,
+          redrawNowPlayingStars
+        }),
+        isLarge: true
+      });
+    }).register();
+    mainElementObserver = new MutationObserver(() => {
+      updateTracklist();
+    });
+    Spicetify.Player.addEventListener("songchange", () => {
+      const trackUri = Spicetify.Player.data.item.uri;
+      if (trackUri in ratings && settings2.skipThreshold !== "disabled" && ratings[trackUri] <= parseFloat(settings2.skipThreshold)) {
+        Spicetify.Player.next();
+        return;
+      }
+      updateNowPlayingWidget();
+    });
+    Spicetify.Platform.History.listen(async () => {
+      await updateAlbumStars();
+    });
+    new Spicetify.ContextMenu.Item(
+      "Use as Rated folder",
+      (uri) => {
+        ratedFolderUri = uri[0];
+        saveRatedFolderUri(ratedFolderUri);
+        ratingsLoading = true;
+        loadRatings().finally(() => {
+          ratingsLoading = false;
+        });
+      },
+      shouldAddContextMenuOnFolders
+    ).register();
+    new Spicetify.ContextMenu.Item(
+      "Sort by rating",
+      (uri) => {
+        Spicetify.PopupModal.display({
+          title: "Modify Custom order?",
+          content: SortModal({
+            onClickCancel: () => {
+              Spicetify.PopupModal.hide();
+            },
+            onClickOK: () => {
+              Spicetify.PopupModal.hide();
+              isSorting = true;
+              showNotification("Sorting...");
+              sortPlaylistByRating(uri[0], ratings).finally(() => {
+                isSorting = false;
+              });
+            }
+          })
+        });
+      },
+      shouldAddContextMenuOnPlaylists
+    ).register();
+    const observer = new MutationObserver(async () => {
+      await observerCallback(keys);
+    });
+    await observerCallback(keys);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+  }
+  var app_default = main;
+
+  // ../../../../Users/seung/AppData/Local/Temp/spicetify-creator/index.jsx
+  (async () => {
+    await app_default();
+  })();
+})();
+(async () => {
+    if (!document.getElementById(`starDratings`)) {
+      var el = document.createElement('style');
+      el.id = `starDratings`;
+      el.textContent = (String.raw`
+  /* ../../../../Users/seung/AppData/Local/Temp/tmp-21528-FgkGpeW3Huhm/198d3919ccd1/settings-ui.css */
+.popup-row::after {
+  content: "";
+  display: table;
+  clear: both;
+}
+.popup-row .col {
+  display: flex;
+  padding: 10px 0;
+  align-items: center;
+}
+.popup-row .col.description {
+  float: left;
+  padding-right: 15px;
+}
+.popup-row .col.action {
+  float: right;
+  text-align: right;
+}
+.popup-row .div-title {
+  color: var(--spice-text);
+}
+.popup-row .divider {
+  height: 2px;
+  border-width: 0;
+  background-color: var(--spice-button-disabled);
+}
+.popup-row .space {
+  margin-bottom: 20px;
+  visibility: hidden;
+}
+button.checkbox {
+  align-items: center;
+  border: 0px;
+  border-radius: 50%;
+  background-color: rgba(var(--spice-rgb-shadow), 0.7);
+  color: var(--spice-text);
+  cursor: pointer;
+  display: flex;
+  margin-inline-start: 12px;
+  padding: 8px;
+}
+button.checkbox.disabled {
+  color: rgba(var(--spice-rgb-text), 0.3);
+}
+select {
+  color: var(--spice-text);
+  background: rgba(var(--spice-rgb-shadow), 0.7);
+  border: 0;
+  height: 32px;
+}
+::-webkit-scrollbar {
+  width: 8px;
+}
+.login-button {
+  background-color: var(--spice-button);
+  border-radius: 8px;
+  border-style: none;
+  box-sizing: border-box;
+  color: var(--spice-text);
+  cursor: pointer;
+  display: inline-block;
+  font-size: 14px;
+  font-weight: 500;
+  height: 40px;
+  line-height: 20px;
+  list-style: none;
+  margin: 10px;
+  outline: none;
+  padding: 5px 10px;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  vertical-align: baseline;
+  touch-action: manipulation;
+}
+
+/* ../../../../Users/seung/AppData/Local/Temp/tmp-21528-FgkGpeW3Huhm/198d3919cca0/sort-modal.css */
+.parent-div {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.button-div {
+  margin-top: 24px;
+  display: flex;
+  gap: 16px;
+  justify-content: flex-end;
+}
+.cancel-button {
+  background-color: transparent;
+  font-weight: 700;
+  border: 0;
+  color: var(--spice-text);
+  display: inline-flex;
+  border-radius: 500px;
+  font-size: inherit;
+  min-block-size: 48px;
+  align-items: center;
+  padding-inline: 32px;
+}
+.cancel-button:hover {
+  transform: scale(1.04);
+}
+.ok-button {
+  background-color: var(--spice-button-active);
+  font-weight: 700;
+  border: 0;
+  color: var(--spice-main);
+  display: inline-flex;
+  border-radius: 500px;
+  font-size: inherit;
+  min-block-size: 48px;
+  align-items: center;
+  padding-inline: 32px;
+}
+.ok-button:hover {
+  transform: scale(1.04);
+}
+
+      `).trim();
+      document.head.appendChild(el);
+    }
+  })()
+      })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "star-ratings",
-  "version": "0.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "star-ratings",
-      "version": "0.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.7"
@@ -1843,6 +1843,7 @@
       "resolved": "https://registry.npmjs.org/spicetify-creator/-/spicetify-creator-1.0.17.tgz",
       "integrity": "sha512-PajJIP0mi8UPErSeuqDf2wF4j8aHF4O+1S9JDIuY4wYKcHHWSvQ21FGnfyxzO6rS4/MkwMDzO6uERnrNAu+sHw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "clean-css": "^5.2.4",

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -99,3 +99,19 @@ export async function moveTracksAfter(playlistUri: string, trackUids, afterUid: 
         { after: isV2 ? { uid: afterUid } : afterUid },
     );
 }
+
+export async function getTracksWithSameISRC(uri: string) {
+    // Get ISRC code for the track
+    const track = await Spicetify.CosmosAsync.get(`https://api.spotify.com/v1/tracks/${uri}`);
+    const isrc = track.external_ids.isrc;
+
+    // Search for tracks with the same ISRC code
+    const query = {
+        q : `isrc:${isrc}`,
+        type: "track",
+        limit: 50, // I don't think there will be more than 50 duplicate songs
+    };
+
+    const response = await Spicetify.CosmosAsync.get(`https://api.spotify.com/v1/search`, query);
+    return response.tracks.items;
+}

--- a/src/settings-ui.tsx
+++ b/src/settings-ui.tsx
@@ -155,6 +155,17 @@ export function Settings({
                     "4.5": "4.5",
                 }}
             />
+            <CheckboxItem
+                settings={settings}
+                name={
+                    <>
+                        Sync duplicate songs with same rating
+                        <br />
+                        (Does not apply to songs that have already been rated)
+                    </>
+                }
+                field="syncDuplicateSongs"
+            />
             <Heading value="Keyboard Shortcuts" />
             <ul>
                 <KeyboardShortcutDescription label="Rate current track 0.5 stars" numberKey="1" />

--- a/src/settings.tsx
+++ b/src/settings.tsx
@@ -8,6 +8,7 @@ export function getSettings() {
         showPlaylistStars: true,
         nowPlayingStarsPosition: "left",
         skipThreshold: "disabled",
+        syncDuplicateSongs: false,
     };
     settings = {};
     try {


### PR DESCRIPTION
**Added "Sync duplicate songs" setting (default: off).**

This new feature automatically synchronizes ratings across different versions of the same song. When you rate a track, the extension now finds all other tracks with the same ISRC (a unique code for a specific sound recording) and updates their ratings to match.

This saves you the effort of manually rating every duplicate track on your playlists. Because the feature ensures all versions of a song share the same rating, you don't need to rate every version of a song individually to set a skip threshold for every version of the song.